### PR TITLE
[Security] Fix Attack Discovery entity flyout opening legacy view instead of Entity Store view

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/get_host_flyout_panel_props.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/get_host_flyout_panel_props.ts
@@ -27,14 +27,17 @@ export const isHostName = (fieldName: string) =>
 export const getHostFlyoutPanelProps = ({
   contextId,
   hostName,
+  entityId,
 }: {
   contextId: string;
   hostName: string;
+  entityId?: string;
 }): FlyoutPanelProps => ({
   id: HostPanelKey,
   params: {
     hostName,
     contextID: contextId,
     scopeId: TableId.alertsOnAlertsPage,
+    ...(entityId ? { entityId } : {}),
   },
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/get_user_flyout_panel_props.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/get_user_flyout_panel_props.ts
@@ -14,14 +14,17 @@ export const isUserName = (fieldName: string) => fieldName === 'user.name';
 export const getUserFlyoutPanelProps = ({
   contextId,
   userName,
+  entityId,
 }: {
   contextId: string;
   userName: string;
+  entityId?: string;
 }): FlyoutPanelProps => ({
   id: UserPanelKey,
   params: {
     userName,
     contextID: contextId,
     scopeId: TableId.alertsOnAlertsPage,
+    ...(entityId ? { entityId } : {}),
   },
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/helpers.ts
@@ -14,17 +14,19 @@ export const getFlyoutPanelProps = ({
   contextId,
   fieldName,
   value,
+  entityId,
 }: {
   contextId: string;
   fieldName: string;
   value: string | number | undefined;
+  entityId?: string;
 }): FlyoutPanelProps | null => {
   if (isHostName(fieldName) && typeof value === 'string') {
-    return getHostFlyoutPanelProps({ contextId, hostName: value });
+    return getHostFlyoutPanelProps({ contextId, hostName: value, entityId });
   }
 
   if (isUserName(fieldName) && typeof value === 'string') {
-    return getUserFlyoutPanelProps({ contextId, userName: value });
+    return getUserFlyoutPanelProps({ contextId, userName: value, entityId });
   }
 
   return null;

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/field_markdown_renderer/index.tsx
@@ -12,18 +12,32 @@ import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 
 import { DraggableBadge } from '../../../../../common/components/draggables';
 import { getFlyoutPanelProps } from './helpers';
+import { isHostName } from './get_host_flyout_panel_props';
+import { isUserName } from './get_user_flyout_panel_props';
 import type { ParsedField } from '../types';
 
 const contextId = 'FieldMarkdownRenderer';
 
-export const getFieldMarkdownRenderer = (disableActions: boolean, scopeId?: string) => {
+export const getFieldMarkdownRenderer = (
+  disableActions: boolean,
+  scopeId?: string,
+  hostEntityIds?: Record<string, string>,
+  userEntityIds?: Record<string, string>
+) => {
   const FieldMarkdownRenderer = ({ icon, name, value }: ParsedField) => {
     const { openRightPanel } = useExpandableFlyoutApi();
     const { euiTheme } = useEuiTheme();
 
+    const entityId = useMemo(() => {
+      if (typeof value !== 'string') return undefined;
+      if (isHostName(name)) return hostEntityIds?.[value];
+      if (isUserName(name)) return userEntityIds?.[value];
+      return undefined;
+    }, [name, value]);
+
     const flyoutPanelProps = useMemo(
-      () => getFlyoutPanelProps({ contextId, fieldName: name, value }),
-      [name, value]
+      () => getFlyoutPanelProps({ contextId, fieldName: name, value, entityId }),
+      [name, value, entityId]
     );
 
     const onEntityClick = useCallback(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_markdown_formatter/index.tsx
@@ -19,12 +19,16 @@ interface Props {
   scopeId?: string;
   disableActions?: boolean;
   markdown: string;
+  hostEntityIds?: Record<string, string>;
+  userEntityIds?: Record<string, string>;
 }
 
 const AttackDiscoveryMarkdownFormatterComponent: React.FC<Props> = ({
   scopeId,
   disableActions = false,
   markdown,
+  hostEntityIds,
+  userEntityIds,
 }) => {
   const attackDiscoveryParsingPluginList = useMemo(
     () => [...getDefaultEuiMarkdownParsingPlugins(), AttackDiscoveryMarkdownParser],
@@ -35,11 +39,13 @@ const AttackDiscoveryMarkdownFormatterComponent: React.FC<Props> = ({
     const processingPluginList = getDefaultEuiMarkdownProcessingPlugins();
     processingPluginList[1][1].components.fieldPlugin = getFieldMarkdownRenderer(
       disableActions,
-      scopeId
+      scopeId,
+      hostEntityIds,
+      userEntityIds
     );
 
     return processingPluginList;
-  }, [disableActions, scopeId]);
+  }, [disableActions, scopeId, hostEntityIds, userEntityIds]);
 
   return (
     <EuiMarkdownFormat

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/actionable_summary/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/actionable_summary/index.tsx
@@ -25,12 +25,16 @@ interface Props {
   attackDiscovery: AttackDiscovery;
   replacements?: Replacements;
   showAnonymized?: boolean;
+  hostEntityIds?: Record<string, string>;
+  userEntityIds?: Record<string, string>;
 }
 
 const ActionableSummaryComponent: React.FC<Props> = ({
   attackDiscovery,
   replacements,
   showAnonymized = false,
+  hostEntityIds,
+  userEntityIds,
 }) => {
   const {
     application: { capabilities },
@@ -82,6 +86,8 @@ const ActionableSummaryComponent: React.FC<Props> = ({
           <AttackDiscoveryMarkdownFormatter
             disableActions={disabledActions}
             markdown={entitySummaryOrTitle}
+            hostEntityIds={hostEntityIds}
+            userEntityIds={userEntityIds}
           />
         </EuiFlexItem>
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/index.tsx
@@ -9,11 +9,16 @@ import { EuiPanel, EuiSpacer, useEuiTheme } from '@elastic/eui';
 import {
   type AttackDiscovery,
   type AttackDiscoveryAlert,
+  getOriginalAlertIds,
   type Replacements,
 } from '@kbn/elastic-assistant-common';
+import { FF_ENABLE_ENTITY_STORE_V2, useEntityStoreEuidApi } from '@kbn/entity-store/public';
 import { css } from '@emotion/react';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
+import { useUiSetting } from '../../../../common/lib/kibana';
+import { useQueryAlerts } from '../../../../detections/containers/detection_engine/alerts/use_query';
+import { ALERTS_QUERY_NAMES } from '../../../../detections/containers/detection_engine/alerts/constants';
 import { ActionableSummary } from './actionable_summary';
 import { PanelHeader } from './panel_header';
 import { Tabs } from './tabs';
@@ -40,8 +45,47 @@ const AttackDiscoveryPanelComponent: React.FC<Props> = ({
   showAnonymized = false,
 }) => {
   const { euiTheme } = useEuiTheme();
+  const entityStoreV2Enabled = useUiSetting<boolean>(FF_ENABLE_ENTITY_STORE_V2);
+  const euidApi = useEntityStoreEuidApi();
 
   const [isOpen, setIsOpen] = useState<'open' | 'closed'>(initialIsOpen ? 'open' : 'closed');
+
+  const originalAlertIds = useMemo(
+    () => getOriginalAlertIds({ alertIds: attackDiscovery.alertIds, replacements }),
+    [attackDiscovery.alertIds, replacements]
+  );
+
+  const alertIdsQuery = useMemo(() => ({ ids: { values: originalAlertIds } }), [originalAlertIds]);
+
+  const { data: alertDocsData } = useQueryAlerts<Record<string, unknown>, unknown>({
+    query: alertIdsQuery,
+    skip: !entityStoreV2Enabled || !euidApi || originalAlertIds.length === 0,
+    queryName: ALERTS_QUERY_NAMES.BY_ID,
+  });
+
+  const [hostEntityIds, userEntityIds] = useMemo<
+    [Record<string, string>, Record<string, string>]
+  >(() => {
+    const hits = alertDocsData?.hits?.hits;
+    if (!euidApi || !hits) return [{}, {}];
+    return hits.reduce<[Record<string, string>, Record<string, string>]>(
+      ([hosts, users], hit) => {
+        const source = (hit as { _source?: Record<string, unknown> })._source ?? hit;
+        const hostName = source['host.name'];
+        const userName = source['user.name'];
+        if (typeof hostName === 'string') {
+          const euid = euidApi.euid.getEuidFromObject('host', source);
+          if (euid) hosts[hostName] = euid;
+        }
+        if (typeof userName === 'string') {
+          const euid = euidApi.euid.getEuidFromObject('user', source);
+          if (euid) users[userName] = euid;
+        }
+        return [hosts, users];
+      },
+      [{}, {}]
+    );
+  }, [euidApi, alertDocsData]);
 
   return (
     <>
@@ -66,6 +110,8 @@ const AttackDiscoveryPanelComponent: React.FC<Props> = ({
           attackDiscovery={attackDiscovery}
           replacements={replacements}
           showAnonymized={showAnonymized}
+          hostEntityIds={hostEntityIds}
+          userEntityIds={userEntityIds}
         />
       </EuiPanel>
 


### PR DESCRIPTION
## Summary

- `FieldMarkdownRenderer` was opening `host-panel`/`user-panel` with only `hostName`/`userName` and no `entityId`. Without `entityId`, `UserPanel`/`HostPanel` cannot resolve an Entity Store record and fall back to the legacy observed-entity view.
- The alerts table path (`PreviewLink`) works correctly because it passes the full alert document and computes the EUID from all contributing identity fields via `euid.getEuidFromObject`.
- Computing EUID from a single field (e.g. `{ 'host.name': value }`) produces the wrong result when the original alert had additional identity fields — EUID is a composite key.

**Fix**: fetch full alert documents at `AttackDiscoveryPanel` (common ancestor of `ActionableSummary` and `AlertsTab`), build `hostEntityIds: Map<string, string>` and `userEntityIds: Map<string, string>` via `euid.getEuidFromObject`, and thread them down to `FieldMarkdownRenderer` so flyout panel params include the correct `entityId`.

Graceful degradation: if `euidApi` is null (loading) or `FF_ENABLE_ENTITY_STORE_V2` is off, the maps are empty and `entityId` is `undefined` — existing behaviour is preserved.

## Files changed (7)

- `attack_discovery_panel/index.tsx` — adds alert fetch + EUID map building
- `actionable_summary/index.tsx` — threads maps down
- `attack_discovery_markdown_formatter/index.tsx` — threads maps down
- `field_markdown_renderer/index.tsx` — resolves `entityId` from maps
- `field_markdown_renderer/helpers.ts` — adds optional `entityId` param
- `get_host_flyout_panel_props.ts` — includes `entityId` in panel params
- `get_user_flyout_panel_props.ts` — includes `entityId` in panel params

## Test plan

- [ ] All existing unit tests pass (`field_markdown_renderer`, `actionable_summary`)
- [ ] Enable `FF_ENABLE_ENTITY_STORE_V2`, open Attack Discovery with real detections, click a host/user name in the header markdown → Entity Store flyout opens
- [ ] With `showAnonymized=true` — no JS errors, names rendered as disabled badges (no regression)
- [ ] With entity store FF off — flyout opens as before (legacy view, no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)